### PR TITLE
Add support for installing splunk forwarder on Ubuntu 14.0.4 based machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+#Ansible files
+playbook.retry
+.vagrant

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
-# splunk-forwarder
-Ansible role to install the splunk forwarder, setup configuration and connect to Splunk Enterprise. Ubuntu/Debian only 
+Role Name
+=========
+
+This role installs the Splunk forwarder, configures basic log watching and forwards those to Splunk.
+
+Requirements
+------------
+None
+
+
+Role Variables
+--------------
+
+Variables with defaults:
+
+* `splunk_server`: IP:PORT of the splunk server to forward to.
+* `splunk_dir`: Path to the splunk directory, the debian package installs to /opt/splunk/ by default.
+* `splunk_download_url`: Full qualified url to a debian install package
+* `splunk_download_md5`: md5 checksum of the package to install. Used verify the package from Splunk.
+
+Variables:
+
+* `splunk_log_items`: A set of log files to forward to splunk.
+```
+- splunk_log_items:
+  - app_name: custom
+    source: "/var/log/messages"
+    index: "syslog"
+    sourcetype: linux_messages_syslog
+```
+
+
+
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+- hosts: all
+  gather_facts: true
+  roles:
+  - role: splunk-forwarder
+
+License
+-------
+
+MIT
+
+Crown Copyright 2016 ONS(UK Office of National Statistics) Digital
+Authors: Dan Hilton
+------------------
+
+
+http://blog.ons.digital/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,19 @@
+# This guide is optimized for Vagrant 1.7 and above.
+# Although versions 1.6.x should behave very similarly, it is recommended
+# to upgrade instead of disabling the requirement below.
+Vagrant.require_version ">= 1.7.0"
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable the new default behavior introduced in Vagrant 1.7, to
+  # ensure that all Vagrant machines will use the same SSH key pair.
+  # See https://github.com/mitchellh/vagrant/issues/5005
+  config.ssh.insert_key = false
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.verbose = "v"
+    ansible.playbook = "playbook.yml"
+  end
+end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+splunk_server: '127.0.0.1:9997'
+splunk_dir: '/opt/splunkforwarder/'
+splunk_download_url: 'https://download.splunk.com/products/universalforwarder/releases/6.3.3/linux/splunkforwarder-6.3.3-f44afce176d0-linux-2.6-amd64.deb'
+splunk_download_md5: '40688513e318aa300a109d1d3f0aa4f4'
+splunk_log_items:
+  - app_name: custom
+    source: "/var/log/messages"
+    index: "syslog"
+    sourcetype: linux_messages_syslog

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for splunk-forwarder

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,171 @@
+galaxy_info:
+  author: your name
+  description: 
+  company: your company (optional)
+  
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+  
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+  
+  min_ansible_version: 1.2
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If travis integration is cofigured, only notification for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+  
+  #
+  # Below are all platforms currently available. Just uncomment
+  # the ones that apply to your role. If you don't see your
+  # platform on this list, let us know and we'll get it added!
+  #
+  #platforms:
+  #- name: EL
+  #  versions:
+  #  - all
+  #  - 5
+  #  - 6
+  #  - 7
+  #- name: GenericUNIX
+  #  versions:
+  #  - all
+  #  - any
+  #- name: Solaris
+  #  versions:
+  #  - all
+  #  - 10
+  #  - 11.0
+  #  - 11.1
+  #  - 11.2
+  #  - 11.3
+  #- name: Fedora
+  #  versions:
+  #  - all
+  #  - 16
+  #  - 17
+  #  - 18
+  #  - 19
+  #  - 20
+  #  - 21
+  #  - 22
+  #  - 23
+  #- name: opensuse
+  #  versions:
+  #  - all
+  #  - 12.1
+  #  - 12.2
+  #  - 12.3
+  #  - 13.1
+  #  - 13.2
+  #- name: IOS
+  #  versions:
+  #  - all
+  #  - any
+  #- name: SmartOS
+  #  versions:
+  #  - all
+  #  - any
+  #- name: eos
+  #  versions:
+  #  - all
+  #  - Any
+  #- name: Windows
+  #  versions:
+  #  - all
+  #  - 2012R2
+  #- name: Amazon
+  #  versions:
+  #  - all
+  #  - 2013.03
+  #  - 2013.09
+  #- name: GenericBSD
+  #  versions:
+  #  - all
+  #  - any
+  #- name: Junos
+  #  versions:
+  #  - all
+  #  - any
+  #- name: FreeBSD
+  #  versions:
+  #  - all
+  #  - 10.0
+  #  - 10.1
+  #  - 10.2
+  #  - 8.0
+  #  - 8.1
+  #  - 8.2
+  #  - 8.3
+  #  - 8.4
+  #  - 9.0
+  #  - 9.1
+  #  - 9.1
+  #  - 9.2
+  #  - 9.3
+  #- name: Ubuntu
+  #  versions:
+  #  - all
+  #  - lucid
+  #  - maverick
+  #  - natty
+  #  - oneiric
+  #  - precise
+  #  - quantal
+  #  - raring
+  #  - saucy
+  #  - trusty
+  #  - utopic
+  #  - vivid
+  #  - wily
+  #  - xenial
+  #- name: SLES
+  #  versions:
+  #  - all
+  #  - 10SP3
+  #  - 10SP4
+  #  - 11
+  #  - 11SP1
+  #  - 11SP2
+  #  - 11SP3
+  #- name: GenericLinux
+  #  versions:
+  #  - all
+  #  - any
+  #- name: NXOS
+  #  versions:
+  #  - all
+  #  - any
+  #- name: Debian
+  #  versions:
+  #  - all
+  #  - etch
+  #  - jessie
+  #  - lenny
+  #  - squeeze
+  #  - wheezy
+  
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is
+    # a keyword that describes and categorizes the role.
+    # Users find roles by searching for tags. Be sure to
+    # remove the '[]' above if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of
+    # alphanumeric characters. Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line.
+  # Be sure to remove the '[]' above if you add dependencies
+  # to this list.

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,10 @@
+- hosts: all
+  vars:
+    splunk_log_items:
+      app_name: custom
+      source: "/var/log/messages"
+      index: "syslog"
+      sourcetype: linux_messages_syslog
+
+  gather_facts: true
+- include: ./tasks/main.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+- hosts: all
+  sudo: yes
+  gather_facts: true
+  vars:
+
+
+  tasks:
+  - name: Set Default variables
+    include_vars: ../defaults/main.yml
+  - name: Download splunk forwarder
+    tags:
+     - ubuntu
+     - debian
+     - download
+    # We have to set validate_certs=False due to download.splunk.com using SNI yet mitigate by checking md5 checksum
+    shell: curl -o /tmp/splunk.deb {{splunk_download_url}}
+
+  - name: create splunk user
+    user: name="splunk" shell="/sbin/nologin" password="!!" groups="" createhome=no
+    tags: user
+
+  - name: Install splunk forwarder
+    tags:
+      - install
+    command: sudo dpkg -i /tmp/splunk.deb
+
+  - name: Chown splunk to {{splunk_dir}}/
+    file: path="{{splunk_dir}}" owner="splunk" group="splunk" recurse="yes" state=directory
+
+  - name: Configure service to start at boot
+    command: "{{splunk_dir}}/bin/splunk enable boot-start -user splunk --accept-license --answer-yes creates={{splunk_dir}}/etc/users/splunk-system-user"
+
+  - name: Accept splunk license
+    command: "{{splunk_dir}}/bin/splunk start --accept-license --answer-yes creates={{splunk_dir}}/etc/users/splunk-system-user"
+    tags: install
+
+  - name: create input configuration with default input files
+    template:
+      src="../templates/inputs_conf.j2"
+      dest="{{splunk_dir}}etc/system/local/inputs.conf"
+      owner="splunk"
+      group="splunk"
+      mode=600
+    with_items:
+      - splunk_log_items
+    tags: config
+
+  - name: create output configuration
+    template:
+      src="outputs_conf.j2"
+      dest="{{splunk_dir}}etc/system/local/outputs.conf"
+      owner="splunk"
+      group="splunk"
+      mode=600
+    with_items: splunk_log_items
+    tags: config
+
+  - name: Start Splunk forwarder service.
+    tags:
+      - config
+      - restart
+      - install
+      - user
+    service: name=splunk state=restarted

--- a/templates/inputs_conf.j2
+++ b/templates/inputs_conf.j2
@@ -1,0 +1,10 @@
+[default]
+host = {{ansible_hostname}}
+
+{% for loggable in splunk_log_items %}
+[monitor://{{loggable.source}}]
+index = {{loggable.index}}
+sourcetype = {{loggable.sourcetype}}
+crcSalt = <SOURCE>
+
+{% endfor %}

--- a/templates/outputs_conf.j2
+++ b/templates/outputs_conf.j2
@@ -1,0 +1,30 @@
+[tcpout]
+defaultGroup = default_output_server
+maxQueueSize = auto
+forwardedindex.0.whitelist = .*
+forwardedindex.1.blacklist = _.*
+forwardedindex.2.whitelist = (_audit|_internal|_introspection)
+forwardedindex.filter.disable = false
+indexAndForward = false
+autoLBFrequency = 30
+blockOnCloning = true
+compressed = true
+disabled = false
+dropClonedEventsOnQueueFull = 5
+dropEventsOnQueueFull = -1
+heartbeatFrequency = 30
+maxFailuresPerInterval = 2
+secsInFailureInterval = 1
+maxConnectionsPerIndexer = 2
+forceTimebasedAutoLB = false
+sendCookedData = true
+connectionTimeout = 20
+readTimeout = 300
+writeTimeout = 300
+useACK = false
+blockWarnThreshold = 100
+
+[tcpout:default_output_server]
+server = {{splunk_server}}
+
+[tcpout-server://{{splunk_server}}]

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - splunk-forwarder

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for splunk-forwarder


### PR DESCRIPTION
**What**

This PR sets up the skeleton for the install of splunk forwarder on
debian based machines. It installs the agent direct from splunk and
creates the input and output config files based on variables. 

**How to test**
1. Install Vagrant
2. Clone this branch 
3. In the root directory, type `vagrant up`
4. Check that the ansible provision completes correctly.
5. SSH into the VM using `vagrant ssh` 
6. Check that the splunk log is recording a failure to connect in the splunk logs 
   (as we don't have a central splunk server to talk to) 
   `tail /opt/splunkforwarder/var/log/splunk/splunkd.log`

**Who can test**

Anyone but @dhilton
